### PR TITLE
portainercc dockerfile

### DIFF
--- a/Dockerfile.portainercc
+++ b/Dockerfile.portainercc
@@ -1,0 +1,18 @@
+from enclaive/gramine-os
+
+COPY ./dist /
+COPY ./coordinator /coordinator 
+
+RUN apt-get update \
+    && apt-get install -y wget \
+    && wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb \
+    && apt-get install -y ./libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb \
+    && rm /lib/x86_64-linux-gnu/libdcap_quoteprov.so \
+    && ln -s /lib/x86_64-linux-gnu/libdcap_quoteprov.so.1.12.102.0 /lib/x86_64-linux-gnu/libdcap_quoteprov.so
+
+RUN sed -i 's,https://localhost:8081/sgx/certification/v3/,https://172.17.0.1:8081/sgx/certification/v3/,g' /etc/sgx_default_qcnl.conf \
+    && sed -i 's,"use_secure_cert": true,"use_secure_cert": false,g' /etc/sgx_default_qcnl.conf \
+    && cat /etc/sgx_default_qcnl.conf
+
+ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
+CMD ["/portainer"]


### PR DESCRIPTION
to build portainercc, run 'yarn build' first and then 'docker build -f Dockerfile.portainercc -t <imagename> .'